### PR TITLE
Refactor get_best_block_hash to use BlockHash::from_hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Documentation](https://docs.rs/bitcoinsv-rpc/badge.svg)](https://docs.rs/bitcoinsv-rpc)
 [![License](https://img.shields.io/crates/l/bitcoinsv-rpc.svg)](./LICENSE)
 
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/Danconnolly/rust-bitcoinsv-rpc?utm_source=oss&utm_medium=github&utm_campaign=Danconnolly%2Frust-bitcoinsv-rpc&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
+
 An async Rust library for interfacing with Bitcoin SV nodes via their JSON-RPC API and REST interface.
 See the documentation at https://docs.rs/bitcoinsv-rpc/latest/bitcoinsv_rpc/.
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -2,6 +2,7 @@
 
 use crate::error::{Error, Result};
 use bitcoinsv::bitcoin::{BlockHash, BlockHeader, Encodable};
+use hex::FromHex;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -95,9 +96,8 @@ impl RpcClient {
     /// Gets the best block hash from the node
     pub async fn get_best_block_hash(&self) -> Result<BlockHash> {
         let hash_str: String = self.call("getbestblockhash", vec![]).await?;
-        let mut bytes = hex::decode(&hash_str)?;
-        bytes.reverse(); // Bitcoin hashes are in reverse byte order
-        Ok(BlockHash::from_slice(&bytes))
+        BlockHash::from_hex(&hash_str)
+            .map_err(|e| Error::BitcoinSv(format!("Failed to parse block hash: {}", e)))
     }
 
     /// Gets the block header for a given block hash

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -209,14 +209,13 @@ async fn test_multiple_concurrent_requests() {
 #[ignore] // Run with: cargo test --test integration_tests -- --ignored
 async fn test_error_handling_invalid_hash() {
     use bitcoinsv::bitcoin::BlockHash;
+    use hex::FromHex;
 
     let client = create_test_client();
 
     // Try to get a block with an invalid hash
     let invalid_hash_str = "0000000000000000000000000000000000000000000000000000000000000000";
-    let mut bytes = hex::decode(invalid_hash_str).expect("Failed to decode hash");
-    bytes.reverse();
-    let invalid_hash = BlockHash::from_slice(&bytes);
+    let invalid_hash = BlockHash::from_hex(invalid_hash_str).expect("Failed to parse hash");
     let result = client.get_block(&invalid_hash).await;
 
     // This should fail


### PR DESCRIPTION
## Summary

- Refactored `RpcClient::get_best_block_hash()` to use the built-in `BlockHash::from_hex()` method
- Removed manual hex decoding and byte reversal logic
- Added `hex::FromHex` trait import to enable the method
- Improved error handling with proper error conversion

The `bitcoinsv::BlockHash` library already provides `Hash::from_hex()` which handles both hex decoding and byte reversal, making the manual implementation unnecessary.

## Test plan

- [x] All existing unit tests pass
- [x] Code formatted with `cargo fmt`
- [x] No clippy warnings with `cargo clippy`
- [x] Verified the refactored function maintains the same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability when retrieving and validating block hashes, reducing malformed results and providing clearer parse error reporting.

- Refactor
  - Simplified internal parsing logic for block hash handling to reduce complexity and potential errors.

- Tests
  - Updated integration tests to align with the simplified parsing behavior and verify error handling.

- Chores
  - Minor cleanup to use standard parsing utilities.

- Documentation
  - Added a pull-request review badge to the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->