### PR TITLE
Add code coverage workflow for PRs and main branch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
       run: cargo tarpaulin --out Xml --output-dir ./coverage
 
     - name: Upload coverage to Codacy
-      uses: codacy/codacy-coverage-reporter-action@v1
+      uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
         coverage-reports: coverage/cobertura.xml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,32 @@
+name: Code Coverage
+
+on:
+  pull_request:
+    branches: ['**']
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
+      with:
+        toolchain: stable
+
+    - name: Install cargo-tarpaulin
+      run: cargo install cargo-tarpaulin
+
+    - name: Generate code coverage
+      run: cargo tarpaulin --out Xml --output-dir ./coverage
+
+    - name: Upload coverage to Codacy
+      uses: codacy/codacy-coverage-reporter-action@v1
+      with:
+        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        coverage-reports: coverage/cobertura.xml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,3 +24,26 @@ jobs:
 
     - name: Run cargo fmt
       run: cargo fmt -- --check
+
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
+      with:
+        toolchain: stable
+
+    - name: Install cargo-tarpaulin
+      run: cargo install cargo-tarpaulin
+
+    - name: Generate code coverage
+      run: cargo tarpaulin --out Xml --output-dir ./coverage
+
+    - name: Upload coverage to Codacy
+      uses: codacy/codacy-coverage-reporter-action@v1
+      with:
+        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        coverage-reports: coverage/cobertura.xml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,26 +24,3 @@ jobs:
 
     - name: Run cargo fmt
       run: cargo fmt -- --check
-
-  coverage:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Setup Rust
-      uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
-      with:
-        toolchain: stable
-
-    - name: Install cargo-tarpaulin
-      run: cargo install cargo-tarpaulin
-
-    - name: Generate code coverage
-      run: cargo tarpaulin --out Xml --output-dir ./coverage
-
-    - name: Upload coverage to Codacy
-      uses: codacy/codacy-coverage-reporter-action@v1
-      with:
-        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        coverage-reports: coverage/cobertura.xml


### PR DESCRIPTION
## Summary

This PR adds code coverage measurement to the CI pipeline:

- **Created `.github/workflows/coverage.yml`**: Dedicated workflow for code coverage that runs on PR events (opened, synchronize, reopened) and pushes to main branch
- **Modified `.github/workflows/rust.yml`**: Keeps main CI workflow focused on quick checks (cargo check and cargo fmt)

## Implementation Details

The coverage workflow uses cargo-tarpaulin to generate XML coverage reports and automatically uploads them to Codacy for tracking coverage metrics over time.

### Trigger Events
- **Pull Requests**: Runs when PRs are opened, updated, or reopened
- **Main Branch**: Runs after merges to main to track coverage on the production branch

## Benefits

- **Targeted execution**: Coverage runs only when needed (PRs and main merges), not on every branch push
- **Code quality insights**: Integration with Codacy provides coverage tracking and trends
- **Efficient CI**: Main CI workflow remains fast for quick feedback on basic checks

## Test plan

- [x] Verified workflow YAML syntax is valid
- [x] Confirmed trigger events are properly configured
- [x] Tested that coverage workflow is separate from main CI workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added automated code-coverage reporting for pull requests and the main branch to improve visibility into test coverage.
  - Generates coverage reports and uploads them to a centralized reporting service for tracking.
  - No changes to application behavior or user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->